### PR TITLE
50 ensure schedulershuffle has parity with schedule run

### DIFF
--- a/content/podcast.go
+++ b/content/podcast.go
@@ -114,15 +114,14 @@ func (p *Podcast) Get() error { //nolint:cyclop,funlen // complexity of 11, igno
 func (p *Podcast) Play() error {
 	log.Infof("streaming from %v ", p.URL)
 
-	if !p.Player.isPlaying {
+	if !p.Player.isPlaying { //nolint:nestif
 		log.WithField("episode", p.EpisodeGUID).Info("setting podcast played cache")
 
 		cacheData, cacheHit := cache.PodcastPlayedCache.Get(defaultPodcastCache)
 		if cacheHit {
-
 			_, ok := cacheData.(podcastCacheData)
 			if ok {
-				podcastCache = cacheData.(podcastCacheData)
+				podcastCache = cacheData.(podcastCacheData) //nolint:forcetypeassert
 
 				if p.EpisodeGUID != "" {
 					podcastCache.Guids = append(podcastCache.Guids, p.EpisodeGUID)
@@ -136,7 +135,6 @@ func (p *Podcast) Play() error {
 		}
 
 		err = p.Player.command.Start()
-
 		if err != nil {
 			return errors.Wrap(err, "podcast.Play::error starting podcast streamPlayer")
 		}

--- a/content/podcast_episodes_internal.go
+++ b/content/podcast_episodes_internal.go
@@ -39,9 +39,9 @@ func (p *podcasts) getNewestEpisode() episode {
 	for i, ep := range p.Episodes {
 		// check for cacheData cache
 		cacheData, cacheHit := cache.PodcastPlayedCache.Get(defaultPodcastCache)
-		log.WithField("data", cacheData).WithField("hit", cacheHit).Info("cache data")
 
 		if cacheHit {
+			log.WithField("data", cacheData).WithField("hit", cacheHit).Debug("cache data")
 			retrieved := (&podcastCacheData{}).fromCache(cacheData) //nolint:exhaustruct // need type casting
 
 			// check for nil retrieved guids

--- a/content/schedule.go
+++ b/content/schedule.go
@@ -77,9 +77,10 @@ func (s *Scheduler) Run() error { //nolint:godox,funlen,gocognit,cyclop,nolintli
 
 				// if p.getMediaType is webRadioContent or podcastContent start a timer and stop content from inside a go routine
 				// because these are streams rather than files they behave differently from local content.
-				switch p.getMediaType() { //nolint:dupl,exhaustive // TODO consider refactoring into function
+				switch p.getMediaType() { //nolint:exhaustive // TODO consider refactoring into function
 				case webRadioContent:
 					log.Info("webradio content detected")
+
 					go func() {
 						duration := getDurationToEndTime(p.Timeslot.End) // might cause an index out of range issue
 						stopCountDown(content, duration, &wg)
@@ -98,6 +99,7 @@ func (s *Scheduler) Run() error { //nolint:godox,funlen,gocognit,cyclop,nolintli
 					}()
 				case podcastContent:
 					log.Info("podcast content detected")
+
 					go func() {
 						podcast := content.(*Podcast) //nolint:forcetypeassert // TODO: type checking
 						log.Infof("podcast player duration %s", podcast.Player.duration)
@@ -105,6 +107,7 @@ func (s *Scheduler) Run() error { //nolint:godox,funlen,gocognit,cyclop,nolintli
 					}()
 
 					wg.Add(1)
+
 					go func() {
 						defer wg.Done()
 						log.Info("playing podcast inside of a go routine")
@@ -217,6 +220,7 @@ func (s *Scheduler) Shuffle() error { //nolint:godox,funlen,gocognit,cyclop,noli
 				}()
 
 				wg.Add(1)
+
 				go func() {
 					defer wg.Done()
 					log.Info("playing web radio inside of a go routine")
@@ -234,9 +238,11 @@ func (s *Scheduler) Shuffle() error { //nolint:godox,funlen,gocognit,cyclop,noli
 				}()
 
 				wg.Add(1)
+
 				go func() {
 					defer wg.Done()
 					log.Info("playing podcast inside of a go routine")
+
 					err = content.Play()
 					if err != nil {
 						log.WithError(err).Error("Run::content.Play")
@@ -253,7 +259,6 @@ func (s *Scheduler) Shuffle() error { //nolint:godox,funlen,gocognit,cyclop,noli
 			wg.Wait()      // pause
 			programIndex++ // increment index
 		}
-
 	}
 
 	exitcode := <-exitchnl


### PR DESCRIPTION
In addition to ensuring that the bugs from Run were removed from Shuffle, this MR handles a TODO to refactor an if statement and fixes a previously unknown issue with go routines spawning multiple players for podcasts & web radio. 