### PR TITLE
#37: Cannot Play All Web Radios

### DIFF
--- a/content/web_radio.go
+++ b/content/web_radio.go
@@ -27,7 +27,7 @@ func (w *WebRadio) Get() error {
 	// setup web radio stream
 	webRadioStream.playerName = streamPlayerName
 	webRadioStream.url = w.URL
-	webRadioStream.command = exec.Command(webRadioStream.playerName, "-quiet", "-playlist", webRadioStream.url)
+	webRadioStream.command = exec.Command(webRadioStream.playerName, "-quiet", webRadioStream.url)
 
 	webRadioStream.in, err = webRadioStream.command.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
closes #37

Remove an argument that got passed to mpv. The argument made the assumption that all web radios were playlists and that is not the case. 

